### PR TITLE
MODBATPRNT-6 upgrade Okapi, folio-vertx-lib, Vert.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <okapi.version>5.3.0-SNAPSHOT</okapi.version>
+    <okapi.version>5.3.0</okapi.version>
     <vertxlib.version>3.2.0-SNAPSHOT</vertxlib.version>
-    <vertx.version>4.5.1</vertx.version>
+    <vertx.version>4.5.3</vertx.version>
     <lombok.version>1.18.30</lombok.version>
     <pdfbox.version>2.0.30</pdfbox.version>
     <jackson.version>2.16.1</jackson.version>

--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <okapi.version>5.3.0</okapi.version>
-    <vertxlib.version>3.2.0-SNAPSHOT</vertxlib.version>
+    <vertxlib.version>3.2.0</vertxlib.version>
     <vertx.version>4.5.3</vertx.version>
     <lombok.version>1.18.30</lombok.version>
     <pdfbox.version>2.0.30</pdfbox.version>

--- a/pom.xml
+++ b/pom.xml
@@ -29,8 +29,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <okapi.version>5.1.2</okapi.version>
-    <vertxlib.version>3.1.3</vertxlib.version>
+    <okapi.version>5.3.0-SNAPSHOT</okapi.version>
+    <vertxlib.version>3.2.0-SNAPSHOT</vertxlib.version>
     <vertx.version>4.5.1</vertx.version>
     <lombok.version>1.18.30</lombok.version>
     <pdfbox.version>2.0.30</pdfbox.version>


### PR DESCRIPTION
Prepare dependencies for Quesnelia (snapshots for now): 

Okapi: 5.3.0-SNAPSHOT
folio-vertx-lib: 3.2.0-SNAPSHOT