### PR TITLE
MODBATPRNT-10 don't use "replaces" for branched out permission

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -180,7 +180,6 @@
     },
     {
       "permissionName": "batch-print.entries.collection.delete",
-      "replaces": ["batch-print.entries.item.delete"],
       "displayName": "batch print - delete print entries",
       "description": "Delete print entries"
     },


### PR DESCRIPTION
A new permission name was branched out from a permission name used for two end-points, which is now non compliant, but the original permission name is in itself still compliant and needed for one of the end points.  Using "replaces" in this scenario breaks the original permission as applied to the one end-point, which then cannot be accessed, as described in [MODBATPRNT-10](https://folio-org.atlassian.net/browse/MODBATPRNT-10).  