### PR TITLE
remove redundant header validation for timer endpoint

### DIFF
--- a/src/main/resources/openapi/batchPrint.yaml
+++ b/src/main/resources/openapi/batchPrint.yaml
@@ -166,7 +166,6 @@ paths:
           $ref: "#/components/responses/trait_500"
   /print/batch-creation:
     parameters:
-      - $ref: headers/okapi-permissions.yaml
       - $ref: headers/okapi-tenant.yaml
       - $ref: headers/okapi-token.yaml
       - $ref: headers/okapi-url.yaml


### PR DESCRIPTION
In the Eureka system we put x-okapi-permissions header only if needed. To force receiving the header x-okapi-permission the endpoint in MD should be defined with permissionsDesired. No permissionsDesired section - No x-okapi-permissions header.